### PR TITLE
Improvements for the reverse taint

### DIFF
--- a/tnt_include.h
+++ b/tnt_include.h
@@ -107,8 +107,8 @@ void TNT_(make_mem_untainted)( Addr a, SizeT len );
 void TNT_(copy_address_range_state) ( Addr src, Addr dst, SizeT len );
 
 // Emits instructions
-VG_REGPARM(1) void TNT_(emit_insn)  ( IRStmt *, UWord, UWord );
-VG_REGPARM(1) void TNT_(emit_insn1) ( IRStmt *, UWord );
+VG_REGPARM(1) void TNT_(emit_insn)  ( IRStmt *, UWord, UWord, UWord );
+VG_REGPARM(1) void TNT_(emit_insn1) ( IRStmt *, UWord, UWord );
 VG_REGPARM(3) void TNT_(emit_next)  ( IRExpr *, UWord, UWord );
 
 /* Functions defined in tnt_translate, used by tnt_main */
@@ -149,6 +149,7 @@ extern Int    TNT_(clo_after_kbb);
 extern Int    TNT_(clo_before_kbb);
 extern Bool   TNT_(clo_tainted_ins_only);
 extern Bool   TNT_(clo_critical_ins_only);
+extern Bool   TNT_(clo_compact);
 extern Bool   TNT_(clo_taint_network);
 extern Bool   TNT_(clo_taint_stdin);
 extern Int    TNT_(do_print);
@@ -241,6 +242,8 @@ extern UInt callgate_nesting_depth;
 /* System call array */
 extern const char* syscallnames[];
 
+extern int istty;
+
 /* Utility functions */
 extern Int TNT_(describe_data)(Addr addr, HChar* varnamebuf, UInt bufsize);
 extern void TNT_(get_fnname)(ThreadId tid, const HChar** buf);
@@ -248,8 +251,8 @@ extern void TNT_(check_fd_access)(ThreadId tid, UInt fd, Int fd_request);
 extern void TNT_(check_var_access)(ThreadId tid, const HChar* varname, Int var_request, enum VariableType type, enum VariableLocation var_loc);
 
 /* Arrays for keeping track of register/tmp SSA indices, values */
-#define TI_MAX 2100 
-#define RI_MAX 240 
+#define TI_MAX 8192 
+#define RI_MAX 8192 
 #define VARNAMESIZE 1024 
 // These arrays are initialised to 0 in TNT_(clo_post_init)
 // Tmp variable indices; the MSB indicates whether it's tainted (1) or not (0)

--- a/tnt_translate.c
+++ b/tnt_translate.c
@@ -6841,11 +6841,10 @@ void create_dirty_EMIT ( MCEnv* mce,
          hname  = "TNT_(emit_insn1)";
 
          IRDirty *di;
-   
          di = unsafeIRDirty_0_N(
                  1/*regparms*/,
                  hname, VG_(fnptr_to_fnentry)( helper ),
-                 mkIRExprVec_2( clone, mkPCastTo(mce, tyAddr, vdata) )
+                 mkIRExprVec_3( clone, mkPCastTo(mce, tyAddr, vdata), mkIRExpr_HWord((HWord)sizeofIRType(ty)))
               );
          setHelperAnns( mce, di );
          stmt( 'V', mce, IRStmt_Dirty(di) );
@@ -6857,7 +6856,6 @@ void create_dirty_EMIT ( MCEnv* mce,
       case Ity_I64:
       {
          IRDirty *di;
-
          if (tyAddr == Ity_I32) {
             helper = &TNT_(emit_insn1);
             hname  = "TNT_(emit_insn1)";
@@ -6865,7 +6863,7 @@ void create_dirty_EMIT ( MCEnv* mce,
             di = unsafeIRDirty_0_N(
                     1/*regparms*/,
                     hname, VG_(fnptr_to_fnentry)( helper ),
-                    mkIRExprVec_2( clone, mkPCastTo(mce, tyAddr, vdata) )
+                    mkIRExprVec_3( clone, mkPCastTo(mce, tyAddr, vdata), mkIRExpr_HWord((HWord)sizeofIRType(ty)))
                  );
          } else {
             helper = &TNT_(emit_insn);
@@ -6874,9 +6872,10 @@ void create_dirty_EMIT ( MCEnv* mce,
             di = unsafeIRDirty_0_N(
                     1/*regparms*/,
                     hname, VG_(fnptr_to_fnentry)( helper ),
-                    mkIRExprVec_3( clone,
+                    mkIRExprVec_4( clone,
                                    zwidenToHostWordC( mce, data ),
-                                   zwidenToHostWord( mce, vdata ))
+                                   zwidenToHostWord( mce, vdata ),
+                                   mkIRExpr_HWord((HWord)sizeofIRType(ty)))
                  );
          }
          setHelperAnns( mce, di );
@@ -6892,13 +6891,20 @@ void create_dirty_EMIT ( MCEnv* mce,
          hname  = "TNT_(emit_insn)";
 
          IRDirty *di;
-   
+         // Ugly hack: there is no sizeof for Ity_I1
+         HWord size;
+         if(ty == Ity_I1)
+            size = 1;
+         else
+            size = sizeofIRType(ty);
+
          di = unsafeIRDirty_0_N(
                  1/*regparms*/,
                  hname, VG_(fnptr_to_fnentry)( helper ),
-                 mkIRExprVec_3( clone,
+                 mkIRExprVec_4( clone,
                                 zwidenToHostWordC( mce, data ),
-                                zwidenToHostWord( mce, vdata ))
+                                zwidenToHostWord( mce, vdata ),
+                                mkIRExpr_HWord(size))
               );
          setHelperAnns( mce, di );
          stmt( 'V', mce, IRStmt_Dirty(di) );


### PR DESCRIPTION
Added log from the read and pread syscalls. Those logs allow tracking… what part of the file has been read.
Added size for Load and Store function in the log. This is helpful when the reverse taint is done.
Added new option "--compact". It makes the output more compact which means smaller and easier to process.
Reverted changes that were not needed.